### PR TITLE
fix: address top 2 security concerns (sed injection + grep regex injection)

### DIFF
--- a/rename-find-replace.sh
+++ b/rename-find-replace.sh
@@ -370,10 +370,10 @@ get_limited_matches() {
     local pattern="$3"
     local counter=0
     
-    local GREP_CMD=(grep -l "$pattern")
+    local GREP_CMD=(grep -Fl "$pattern")
     # Use -I to ignore binary matches when skipping binary
     if [[ $PROCESS_BINARY -eq 0 ]]; then
-        GREP_CMD=(grep -Il "$pattern")
+        GREP_CMD=(grep -IFl "$pattern")
     fi
     if [[ ${#FIND_EXCLUSIONS[@]} -eq 0 && ${#NEGATION_CONDITIONS[@]} -eq 0 ]]; then
         # No exclusions at all
@@ -437,7 +437,7 @@ FILE_RENAMED_COUNT=0
 MATCH_CONTENT_FILES=()
 if [[ $SKIP_CONTENTS -eq 0 ]]; then
     log_step "Scanning for content matches"
-    GREP_CONTENT=(grep -l "$FIND"); [[ $PROCESS_BINARY -eq 0 ]] && GREP_CONTENT=(grep -Il "$FIND")
+    GREP_CONTENT=(grep -Fl "$FIND"); [[ $PROCESS_BINARY -eq 0 ]] && GREP_CONTENT=(grep -IFl "$FIND")
     if [[ ${#FIND_EXCLUSIONS[@]} -eq 0 && ${#NEGATION_CONDITIONS[@]} -eq 0 ]]; then
         while IFS= read -r f; do MATCH_CONTENT_FILES+=("$f"); progress_bar ${#MATCH_CONTENT_FILES[@]} 0 "Collect"; done < <(find . -type f -exec "${GREP_CONTENT[@]}" {} \; 2>/dev/null)
     elif [[ ${#NEGATION_CONDITIONS[@]} -gt 0 ]]; then

--- a/rename-find-replace.sh
+++ b/rename-find-replace.sh
@@ -271,6 +271,14 @@ fi
 FIND="$1"
 REPLACE="$2"
 
+# Escape FIND and REPLACE for safe interpolation into sed substitution expressions.
+# Without escaping, user-supplied values containing '/' or sed flags (e.g. /e) allow
+# arbitrary shell-command execution via GNU sed's 'e' flag (CVE-class: command injection).
+#   FIND_SED  : escaped for use as a BRE pattern (delimiter + regex metacharacters)
+#   REPLACE_SED: escaped for use as a replacement string (delimiter, & and \)
+FIND_SED=$(printf '%s\n' "$FIND" | sed 's/[[\.*^$()+?{|]/\\&/g; s|/|\\/|g')
+REPLACE_SED=$(printf '%s\n' "$REPLACE" | sed 's/[&\]/\\&/g; s|/|\\/|g')
+
 # Read patterns from .renamerignore files
 ignore_file_result=$(read_ignore_files)
 IFS='|' read -ra ignore_file_parts <<< "$ignore_file_result"
@@ -528,7 +536,7 @@ case "$USER_RESPONSE" in
         if [[ $SKIP_CONTENTS -eq 0 && ${#MATCH_CONTENT_FILES[@]} -gt 0 ]]; then
             total=${#MATCH_CONTENT_FILES[@]}; idx=0
             for f in "${MATCH_CONTENT_FILES[@]}"; do
-                sed -i "s/$FIND/$REPLACE/g" "$f" && ((CONTENT_REPLACED_COUNT++))
+                sed -i "s/$FIND_SED/$REPLACE_SED/g" "$f" && ((CONTENT_REPLACED_COUNT++))
                 ((idx++)); progress_bar "$idx" "$total" "Content"
             done
             finish_progress


### PR DESCRIPTION
## Security Fixes

This PR addresses the two most impactful security concerns identified in `rename-find-replace.sh`.

---

### 1. `sed` Command Injection via Unescaped FIND/REPLACE (delimiter injection)

**Severity: High**

```bash
# Before
sed -i "s/$FIND/$REPLACE/g" "$f"
```

If `FIND` or `REPLACE` contained `/` (the sed delimiter), the command became syntactically malformed — sed would silently mis-parse the expression, treating part of the user input as sed flags or commands. In GNU sed, this opens the door to the `e` flag (execute matched text as shell command), making this a potential arbitrary code execution vector.

**Fix:** Pre-escape `FIND` and `REPLACE` into `FIND_SED` / `REPLACE_SED` variables, escaping regex metacharacters in the pattern and `&`/`\\` in the replacement, before interpolating into `sed`.

---

### 2. `grep` Regex Injection via Unescaped FIND Pattern

**Severity: Medium**

```bash
# Before
grep -l "$FIND"      # FIND treated as a regex
grep -Il "$FIND"
```

`grep` was treating the user-supplied `FIND` argument as a **regular expression**. Characters like `.`, `*`, `[`, `+`, `?`, `(`, `)` have special regex meaning. For example:
- `FIND=.` → matches *every* file (any character), causing sed to run on all files
- `FIND=.*` → same broad match
- `FIND=[abc]` → matches files containing 'a', 'b', or 'c' individually

This causes unintended files to be included in the match set and then modified by sed, corrupting content the user never intended to touch.

**Fix:** Add the `-F` (`--fixed-strings`) flag to all `grep` invocations that use `FIND`, making grep treat it as a literal string.

```bash
# After
grep -Fl "$FIND"
grep -IFl "$FIND"
```

---

### Testing

All 16 existing tests pass with these changes:

```
Total: 16  Failed: 0
All tests passed.
```